### PR TITLE
Exclude vendor directory

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -1,12 +1,16 @@
 version = 1
 
 exclude_patterns = [
-  "**/vendor/**"
+  "**/vendor/**",
+  "tmp/**"
 ]
 
 [[analyzers]]
 name = "php"
 enabled = true
+
+[analyzers.meta]
+  bootstrap_files = ["config/bootstrap.php"]
 
 [[analyzers]]
 name = "shell"

--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -1,5 +1,9 @@
 version = 1
 
+exclude_patterns = [
+  "**/vendor/**"
+]
+
 [[analyzers]]
 name = "php"
 enabled = true


### PR DESCRIPTION
👋 Hey there, we noticed there was an analysis time for this repository because of too many files for analysis. Upon checking I found that vendor directory is not excluded from analysis. Since these directories often contain code from the third party, it is not good idea to analyse and fix other's code.

To exclude files from the analysis add [`exclude_patterns`](https://deepsource.io/docs/concepts#exclude_patterns) in the `.deepsource.toml` config file. Here, I've added `vendor/` and `tmp/` folder from the analysis. This should fix the analysis timeout problem.

Hope this helps!